### PR TITLE
Fix issue where `copy` would not correctly copy to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where `copy` would not correctly copy release text with new lines
 
 ## [0.2.0] - 2020-01-11
 ### Added

--- a/kac/changelog.py
+++ b/kac/changelog.py
@@ -127,14 +127,16 @@ class Changelog:
         :return: Nothing.
         """
         version: Tuple[int, int, int] = self._get_most_recent_version() if v == self.LATEST else v
-        save_lines = False
+        save_lines = False  # Whether or not we should be saving lines
         text = ''
         pattern = re.compile(self._version_title_re_pattern)
         with open(self.changelog_file_path) as f:
-            for line in f:
+            for line in f:  # Run through each line of the CHANGELOG
                 if save_lines:
-                    if not line.strip():
+                    # Stop saving release text ff the line matches the release title regex pattern
+                    if pattern.match(line):
                         save_lines = False
+                    # Add the line to the release text we need to copy
                     else:
                         text += line
                 else:

--- a/kac/changelog.py
+++ b/kac/changelog.py
@@ -133,7 +133,7 @@ class Changelog:
         with open(self.changelog_file_path) as f:
             for line in f:  # Run through each line of the CHANGELOG
                 if save_lines:
-                    # Stop saving release text ff the line matches the release title regex pattern
+                    # Stop saving release text if the line matches the release title regex pattern
                     if pattern.match(line):
                         save_lines = False
                     # Add the line to the release text we need to copy


### PR DESCRIPTION
This could occur when there were different types of changes in a release
that were separated by a new line.