### PR TITLE
Merge pull request #10 from atwalsh/title-re-digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where `bump` would not properly show the latest version 
 
 ## [0.2.1] - 2020-01-11
 ### Fixed

--- a/kac/changelog.py
+++ b/kac/changelog.py
@@ -13,7 +13,7 @@ rreplace = lambda s, old, new, occurrence: new.join(s.rsplit(old, occurrence))  
 
 class Changelog:
     # Regex patterns
-    _version_title_re_pattern: str = '\#\#\s\[(\d)\.(\d)\.(\d+)\].*'
+    _version_title_re_pattern: str = '\#\#\s\[(\d+)\.(\d+)\.(\d+)\].*'
     _version_re_pattern: str = 'v?(\d+)\.(\d+)\.(\d+)'
     _unreleased_url_re_pattern: str = '\[Unreleased\]:'
     _unreleased_tag_re_pattern: str = f'\#\#\s\[Unreleased\].*'


### PR DESCRIPTION
This could cause the bump command to show an incorrect latest version
which would lead to an incorrect list of possible new versions. The `+`
character was missing from the regex pattern in two places, preventing
major and minor versions with more than a single digit from matching.