### PR TITLE
Remove whitespace and newline characters from end of copied version text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where extra newline characters were copied to the clipboard
 
 ## [0.2.2] - 2020-01-14
 ### Fixed

--- a/kac/changelog.py
+++ b/kac/changelog.py
@@ -146,7 +146,7 @@ class Changelog:
                         save_lines = True
         if not text:
             raise LookupError(f'Could not find version number {self.format_version(v, include_v=True)}')
-        pyperclip.copy(text)
+        pyperclip.copy(text.rstrip('\n '))
         click.echo(f'{self.format_version(version, include_v=True)} release text copied to clipboard!')
 
     def format_version(self, v: Tuple[int, int, int], include_v: bool = True) -> str:


### PR DESCRIPTION
Fixes #12