### PR TITLE
Add `initial_release_date` to CHANGELOG file template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `kac init` did not include a date for the first release when generating new CHANGELOG files (#28)
 
 ## [0.4.0] - 2021-02-11
 ### Changed

--- a/kac/changelog/changelog.py
+++ b/kac/changelog/changelog.py
@@ -41,7 +41,6 @@ class Changelog:
 
         # Parse Unreleased section
         m_unreleased = re.match(r'## \[Unreleased]\n((?:### \w+[\n\s]*(?:-[ \S]*[\s]+)*)*)', self._body_text)
-        # if m_unreleased.groups()[0].strip() != '':
         self.unreleased = Unreleased(**Unreleased.changes_to_dict(m_unreleased.groups()[0].strip()))
 
         # Parse releases from the body section

--- a/kac/kac.py
+++ b/kac/kac.py
@@ -1,4 +1,5 @@
 import os
+from datetime import date
 
 import click
 import pyperclip
@@ -104,7 +105,8 @@ def init(filename):
     env = Environment(loader=PackageLoader('kac', 'templates'), )
     changelog_template = env.get_template('CHANGELOG.md')
     # Render the template with user input
-    new_file_text = changelog_template.render(initial_release=version, repo_url=github_repo_url)
+    new_file_text = changelog_template.render(initial_release=version, repo_url=github_repo_url,
+                                              initial_release_date=date.today())
 
     # Write the new CHANGELOG file
     try:

--- a/kac/templates/CHANGELOG.md
+++ b/kac/templates/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [{{initial_release}}]
+## [{{initial_release}}] - {{initial_release_date}}
 
 
 [Unreleased]: {{repo_url}}/compare/v{{initial_release}}...HEAD

--- a/tests/files/test_init_file.md
+++ b/tests/files/test_init_file.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1]
+## [0.0.1] - 2021-06-12
 
 
 [Unreleased]: https://github.com/atwalsh/kac/compare/v0.0.1...HEAD

--- a/tests/test_kac/test_init.py
+++ b/tests/test_kac/test_init.py
@@ -2,11 +2,13 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from click.testing import CliRunner
+from freezegun import freeze_time
 
 from kac.kac import init
 
 
 class TestInit:
+    @freeze_time("2021-06-12")
     def test_creation(self, monkeypatch):
         runner = CliRunner()
         expected_path = f'{Path(__file__).parent.parent.resolve()}/files/test_init_file.md'


### PR DESCRIPTION
Adds an `initial_releas_date` to the new CHANGELOG file template. Defaults to `datetime.date.today()`.

Fixes #28