### PR TITLE
Allow for extra newlines below `## [Unreleased]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- `kac init` did not include a date for the first release when generating new CHANGELOG files (#28)
+- `kac init` did not include a date for the first release when generating new CHANGELOG files
+- Update unreleased regex pattern to allow for an extra newline below `## [Unreleased]`
 
 ## [0.4.0] - 2021-02-11
 ### Changed

--- a/kac/changelog/changelog.py
+++ b/kac/changelog/changelog.py
@@ -40,7 +40,7 @@ class Changelog:
         self._header_text, self._body_text, self._footer_text = m_file.groups()  # type: str, str, str
 
         # Parse Unreleased section
-        m_unreleased = re.match(r'## \[Unreleased]\n((?:### \w+[\n\s]*(?:-[ \S]*[\s]+)*)*)', self._body_text)
+        m_unreleased = re.match(r'## \[Unreleased]\n+((?:### \w+[\n\s]*(?:-[ \S]*[\s]+)*)*)', self._body_text)
         self.unreleased = Unreleased(**Unreleased.changes_to_dict(m_unreleased.groups()[0].strip()))
 
         # Parse releases from the body section


### PR DESCRIPTION
Also verified other regex patterns against the existing CHANGELOG.md file with newline characters below each header section.

Fixes #29 