### PR TITLE
Add `get_first_git_remote` util method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Try to parse the first git remote URL from `.git/config` when generating CHANGELOG 
+  files with `kac init`
+
 ### Fixed
 - `kac init` did not include a date for the first release when generating new CHANGELOG files
 - Update unreleased regex pattern to allow for an extra newline below `## [Unreleased]`

--- a/kac/kac.py
+++ b/kac/kac.py
@@ -6,7 +6,7 @@ import pyperclip
 import questionary
 from jinja2 import Environment, PackageLoader
 from semver import VersionInfo
-
+from .util import get_first_git_remote
 from .changelog import Changelog
 
 
@@ -96,7 +96,7 @@ def init(filename):
     # Ask the user for their GitHub repository URL
     github_repo_url: str = questionary.text(
         message='Enter Repository URL',
-        default='https://github.com/atwalsh/kac',
+        default=get_first_git_remote() or 'https://github.com/atwalsh/kac',
     ).ask()
     if github_repo_url is None:
         raise click.Abort

--- a/kac/util.py
+++ b/kac/util.py
@@ -1,0 +1,21 @@
+import configparser
+import re
+
+
+def get_first_git_remote() -> str:
+    """
+    Attempt to get the first git remote URL from the ./.git/config file in the current directory.
+    :return: URL for the first git remote or an empty string if a remote URL could not be identified.
+    """
+    git_config = configparser.ConfigParser()
+    try:
+        files = git_config.read('./.git/config')
+    except configparser.Error:
+        return ''
+    if not files or len(files) > 1:  # ConfigParser.read() returns a list of successfully read files
+        return ''
+
+    for section in git_config.sections():
+        if section.startswith('remote'):
+            remote = git_config[section].get('url')
+            return re.sub(r'\.git$', '', remote)

--- a/tests/test_util/test_util.py
+++ b/tests/test_util/test_util.py
@@ -1,0 +1,13 @@
+import io
+from unittest.mock import patch
+
+from kac.util import get_first_git_remote
+
+
+class TestUtil:
+    def test_get_first_git_remote(self):
+        test_config_data = '[remote "origin"]\n\turl = https://github.com/atwalsh/test.git' \
+                           '\n\tfetch = +refs/heads/*:refs/remotes/origin/*'
+        with patch("configparser.open") as mocked_open:
+            mocked_open.return_value = io.StringIO(test_config_data)
+            assert get_first_git_remote() == 'https://github.com/atwalsh/test'


### PR DESCRIPTION
Closes #30 

### Added
- Try to parse the first git remote URL from `.git/config` when generating CHANGELOG 
  files with `kac init`